### PR TITLE
support install package

### DIFF
--- a/builder/alpine/install.sh
+++ b/builder/alpine/install.sh
@@ -2,14 +2,14 @@
 COMMANDS=$1
 PACKAGES=
 # @todo why can I not make the IFS work here?!
+apk update
 while read COMMAND; do
-    if [ "$COMMAND" = "@*" ]; then
-      PACKAGE=${COMMAND:1}
-    else
-      PACKAGE=$(curl -sSfL "https://command-not-found.com/-/api/package/alpine/$COMMAND")
+    PACKAGE=$(curl -sSfL "https://command-not-found.com/-/api/package/alpine/$COMMAND")
+    if [ -z "${PACKAGE}" ] && apk info ${COMMAND} 1>&2 2>/dev/null; then
+      PACKAGE=${COMMAND}
     fi
-    
-    if apk info | grep -qE "^${PACKAGE}$" >/dev/null; then
+
+    if [ -n "${PACKAGE}" ] && apk info | grep -qE "^${PACKAGE}$" >/dev/null; then
         echo "Notice: Package already installed"
         exit 0
     fi
@@ -21,5 +21,6 @@ if [ -z "$PACKAGES" ]; then
     echo "Error: Nothing to install"
     exit 1
 fi
-apk --no-cache add ${PACKAGES}
+apk add ${PACKAGES}
+rm -rf /var/cache/apk/*
 exit 0

--- a/builder/alpine/install.sh
+++ b/builder/alpine/install.sh
@@ -3,7 +3,12 @@ COMMANDS=$1
 PACKAGES=
 # @todo why can I not make the IFS work here?!
 while read COMMAND; do
-    PACKAGE=$(curl -sSfL "https://command-not-found.com/-/api/package/alpine/$COMMAND")
+    if [ "$COMMAND" = "@*" ]; then
+      PACKAGE=${COMMAND:1}
+    else
+      PACKAGE=$(curl -sSfL "https://command-not-found.com/-/api/package/alpine/$COMMAND")
+    fi
+    
     if apk info | grep -qE "^${PACKAGE}$" >/dev/null; then
         echo "Notice: Package already installed"
         exit 0


### PR DESCRIPTION
fix #8 

Install.sh will try to search a package after command-not-found.com returns empty.

sample:

docker pull 192.168.1.200:5050/curl/stress-ng/iproute2:latest